### PR TITLE
Use lodash _.sample for getting a random word

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,4 @@ Werkend spel:
 - Geavanceerd: animatie veranderen (invouwen, uit beeld laten verdwijnen)
 
 ### Code
-- Random is niet goed verdeeld als er meer woorden worden toegevoegd, `round` maakt kans op 0 en laatste index kleiner dan de andere indices.
 - Het hoofd kan waarschijnlijk met 100% `border-radius` CSS, zodat er geen SVG nodig is.

--- a/galgje.js
+++ b/galgje.js
@@ -7,7 +7,7 @@ const alleWoorden = [
     {woord: "bibliotheek", omschrijving: "Waar houden we de Coderdojo?"},
 ];
 
-const huidigWoord = alleWoorden[Math.round(Math.random() * (alleWoorden.length - 1))];
+const huidigWoord = _.sample(alleWoorden)
 
 veranderText('omschrijving', huidigWoord.omschrijving);
 maakLeeg('woord');

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Galgje</title>
   <meta name="viewport" content="width=device-width, initial-scale=0.86, maximum-scale=5.0, minimum-scale=0.86">
   <link href="style.css" rel="stylesheet">
+
+  <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
- Included lodash in index.html (cdn)
- Use lodash _.sample for picking a random word since this is a "better" random. The disadvantage of using Math.round(Math.random() * ...) is that some array entries are picked far more often then others (as described in the readme)